### PR TITLE
Cargo fmt and bump dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-debug"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Niklas <nicke.l@telia.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2018"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name	= "rust-debug"
+name = "rust-debug"
 version = "0.1.0"
 authors = ["Niklas <nicke.l@telia.com>"]
 license = "MIT OR Apache-2.0"
@@ -15,7 +15,6 @@ keywords = ["debug", "debugging"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-gimli			= "0.26"
-anyhow			= "1.0"
-log			= "0.4"
-
+gimli = "0.31.1"
+anyhow = "1.0"
+log = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-debug"
-version = "0.2.0"
+version = "0.1.1"
 authors = ["Niklas <nicke.l@telia.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2018"

--- a/src/evaluate/mod.rs
+++ b/src/evaluate/mod.rs
@@ -1,11 +1,12 @@
-/// Contains functions for retrieving the values of some of the DWARF attributes.
+/// Contains functions for retrieving the values of some of the DWARF
+/// attributes.
 pub mod attributes;
 
 /// Contains structs representing the different Rust data types and more.
 pub mod evaluate;
 
-use crate::call_stack::MemoryAccess;
-use crate::registers::Registers;
+use std::convert::TryInto;
+
 use anyhow::{anyhow, Result};
 use evaluate::{convert_to_gimli_value, BaseTypeValue, EvaluatorValue};
 use gimli::{
@@ -19,7 +20,8 @@ use gimli::{
     Expression, Reader, Unit, UnitOffset,
 };
 use log::{error, info};
-use std::convert::TryInto;
+
+use crate::{call_stack::MemoryAccess, registers::Registers};
 
 /// Will find the DIE representing the type can evaluate the variable.
 ///
@@ -34,8 +36,8 @@ use std::convert::TryInto;
 /// * `registers` - A register struct for accessing the register values.
 /// * `mem` - A struct for accessing the memory of the debug target.
 ///
-/// This function is used to find the DIE representing the type and then to evaluate the value of
-/// the given DIE>
+/// This function is used to find the DIE representing the type and then to
+/// evaluate the value of the given DIE>
 pub fn call_evaluate<R: Reader<Offset = usize>, T: MemoryAccess>(
     dwarf: &Dwarf<R>,
     pc: u32,
@@ -118,9 +120,11 @@ pub fn call_evaluate<R: Reader<Offset = usize>, T: MemoryAccess>(
 /// * `pc` - A machine code address, usually the current code location.
 /// * `expr` - The expression to be evaluated.
 /// * `frame_base` - The frame base address value.
-/// * `type_unit` - A compilation unit which contains the given DIE which represents the type of
+/// * `type_unit` - A compilation unit which contains the given DIE which
+///   represents the type of
 /// the given expression. None if the expression does not have a type.
-/// * `type_die` - The DIE the represents the type of the given expression. None if the expression
+/// * `type_die` - The DIE the represents the type of the given expression. None
+///   if the expression
 /// does not have a type.
 /// * `registers` - A register struct for accessing the register values.
 /// * `mem` - A struct for accessing the memory of the debug target.
@@ -139,7 +143,6 @@ pub fn evaluate<R: Reader<Offset = usize>, T: MemoryAccess>(
     mem: &mut T,
 ) -> Result<EvaluatorValue<R>> {
     let pieces = evaluate_pieces(dwarf, unit, pc, expr, frame_base, registers, mem)?;
-    info!("Got pieces");
     evaluate_value(dwarf, pieces, type_unit, type_die, registers, mem)
 }
 
@@ -149,9 +152,11 @@ pub fn evaluate<R: Reader<Offset = usize>, T: MemoryAccess>(
 ///
 /// * `dwarf` - A reference to gimli-rs `Dwarf` struct.
 /// * `pieces` - A list of gimli-rs pieces containing the location information..
-/// * `type_unit` - A compilation unit which contains the given DIE which represents the type of
+/// * `type_unit` - A compilation unit which contains the given DIE which
+///   represents the type of
 /// the given expression. None if the expression does not have a type.
-/// * `type_die` - The DIE the represents the type of the given expression. None if the expression
+/// * `type_die` - The DIE the represents the type of the given expression. None
+///   if the expression
 /// does not have a type.
 /// * `registers` - A register struct for accessing the register values.
 /// * `mem` - A struct for accessing the memory of the debug target.
@@ -199,7 +204,8 @@ pub fn evaluate_value<R: Reader<Offset = usize>, T: MemoryAccess>(
 /// * `mem` - A struct for accessing the memory of the debug target.
 ///
 /// This function will evaluate the given expression into a list of pieces.
-/// These pieces describe the size and location of the variable the given expression is from.
+/// These pieces describe the size and location of the variable the given
+/// expression is from.
 pub fn evaluate_pieces<R: Reader<Offset = usize>, T: MemoryAccess>(
     dwarf: &Dwarf<R>,
     unit: &Unit<R>,
@@ -355,7 +361,9 @@ pub fn evaluate_pieces<R: Reader<Offset = usize>, T: MemoryAccess>(
             RequiresRelocatedAddress(_num) => {
                 error!("Unimplemented");
                 return Err(anyhow!("Unimplemented"));
-                //                result = eval.resume_with_relocated_address(num)?; // TODO: Check and test if correct.
+                //                result =
+                // eval.resume_with_relocated_address(num)?; // TODO: Check and
+                // test if correct.
             }
 
             RequiresIndexedAddress {
@@ -365,21 +373,23 @@ pub fn evaluate_pieces<R: Reader<Offset = usize>, T: MemoryAccess>(
                 // TODO: Check and test if correct. Also handle relocate flag
                 error!("Unimplemented");
                 return Err(anyhow!("Unimplemented"));
-                //                result = eval.resume_with_indexed_address(dwarf.address(unit, index)?)?;
+                //                result =
+                // eval.resume_with_indexed_address(dwarf.address(unit,
+                // index)?)?;
             }
 
             RequiresBaseType(unit_offset) => {
                 let die = unit.entry(unit_offset)?;
                 let mut attrs = die.attrs();
-                while let Some(attr) = match attrs.next() {
+                while let Some(_attr) = match attrs.next() {
                     Ok(val) => val,
                     Err(err) => {
                         error!("{:?}", err);
                         return Err(anyhow!("{:?}", err));
                     }
                 } {
-                    println!("Attribute name = {:?}", attr.name());
-                    println!("Attribute value = {:?}", attr.value());
+                    // println!("Attribute name = {:?}", attr.name());
+                    // println!("Attribute value = {:?}", attr.value());
                 }
 
                 error!("Unimplemented");
@@ -395,12 +405,15 @@ pub fn evaluate_pieces<R: Reader<Offset = usize>, T: MemoryAccess>(
 ///
 /// Description:
 ///
-/// * `unit` - A compilation unit which contains the type DIE pointed to by the given offset.
+/// * `unit` - A compilation unit which contains the type DIE pointed to by the
+///   given offset.
 /// * `unit` - The value to parse in bytes.
-/// * `base_type` - A offset into the given compilation unit which points to a DIE with the tag
+/// * `base_type` - A offset into the given compilation unit which points to a
+///   DIE with the tag
 /// `DW_TAG_base_type`.
 ///
-/// This function will parse the given value into the type given by the offset `base_type`.
+/// This function will parse the given value into the type given by the offset
+/// `base_type`.
 fn eval_base_type<R>(
     unit: &gimli::Unit<R>,
     data: Vec<u8>,
@@ -469,22 +482,26 @@ where
     BaseTypeValue::parse_base_type(data, encoding)
 }
 
-/// Will evaluate a value that is required when evaluating a expression into pieces.
+/// Will evaluate a value that is required when evaluating a expression into
+/// pieces.
 ///
 /// Description:
 ///
 /// * `dwarf` - A reference to gimli-rs `Dwarf` struct.
 /// * `unit` - A compilation unit which contains the given DIE.
 /// * `pc` - A machine code address, usually the current code location.
-/// * `eval` - A gimli-rs `Evaluation` that will be continued with the new value.
-/// * `result` - A gimli-rs `EvaluationResult` that will be updated with the new evaluation result.
+/// * `eval` - A gimli-rs `Evaluation` that will be continued with the new
+///   value.
+/// * `result` - A gimli-rs `EvaluationResult` that will be updated with the new
+///   evaluation result.
 /// * `frame_base` - The frame base address value.
-/// * `unit_offset` - A offset to the DIE that will be evaluated and added to the given `Evaluation` struct.
+/// * `unit_offset` - A offset to the DIE that will be evaluated and added to
+///   the given `Evaluation` struct.
 /// * `registers` - A register struct for accessing the register values.
 /// * `mem` - A struct for accessing the memory of the debug target.
 ///
-/// This function is a helper function for continuing a `Piece` evaluation where another value
-/// needs to be evaluated first.
+/// This function is a helper function for continuing a `Piece` evaluation where
+/// another value needs to be evaluated first.
 fn help_at_location<R: Reader<Offset = usize>, T: MemoryAccess>(
     dwarf: &Dwarf<R>,
     unit: &Unit<R>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,21 +1,22 @@
 //! Easy to use DWARF abstraction for Rust.
 //!
-//! Provides an abstraction over DWARF. The abstraction provides a one function solution for
-//! retrieving debug information from DWARF.
+//! Provides an abstraction over DWARF. The abstraction provides a one function
+//! solution for retrieving debug information from DWARF.
 //! Here are some of the  advantages:
 //! - Easy to use
-//!
 
 /// Provides one function solutions for doing a stack trace
 pub mod call_stack;
 
-/// Provides one function solutions for handling evaluation the DWARF location attribute.
+/// Provides one function solutions for handling evaluation the DWARF location
+/// attribute.
 pub mod evaluate;
 
 /// Defines a struct containing information about the registers
 pub mod registers;
 
-/// Provides one function solutions for retrieving the source location declaration information.
+/// Provides one function solutions for retrieving the source location
+/// declaration information.
 pub mod source_information;
 
 /// Provides some useful functions for reading the DWARF format.

--- a/src/variable.rs
+++ b/src/variable.rs
@@ -1,17 +1,18 @@
+use anyhow::{anyhow, Result};
 use gimli::{
     AttributeValue::{DebugInfoRef, DebugStrRef, Exprloc, LocationListsRef, UnitRef},
     DebuggingInformationEntry, Dwarf, Reader, Unit, UnitOffset, UnitSectionOffset,
 };
-
-use crate::evaluate::attributes;
-use crate::evaluate::evaluate;
-use crate::registers::Registers;
-use crate::source_information::SourceInformation;
-use crate::utils::in_range;
-use crate::variable::evaluate::EvaluatorValue;
-use crate::{call_stack::MemoryAccess, utils::DwarfOffset};
-use anyhow::{anyhow, Result};
 use log::{error, info, trace};
+
+use crate::{
+    call_stack::MemoryAccess,
+    evaluate::{attributes, evaluate},
+    registers::Registers,
+    source_information::SourceInformation,
+    utils::{in_range, DwarfOffset},
+    variable::evaluate::EvaluatorValue,
+};
 
 /// Defines what debug information a variable has.
 #[derive(Debug, Clone)]
@@ -19,7 +20,8 @@ pub struct Variable<R: Reader<Offset = usize>> {
     /// The name of the variable.
     pub name: Option<String>,
 
-    /// A tree structured like the variable type in DWARF, but it also contains the values
+    /// A tree structured like the variable type in DWARF, but it also contains
+    /// the values
     pub value: EvaluatorValue<R>,
 
     /// The source code location where the variable was declared.
@@ -33,17 +35,21 @@ impl<R: Reader<Offset = usize>> Variable<R> {
     ///
     /// * `dwarf` - A reference to gimli-rs `Dwarf` struct.
     /// * `registers` - A reference to the `Registers` struct.
-    /// * `memory` - A reference to a struct that implements the `MemoryAccess` trait.
-    /// * `section_offset` - A offset to the compilation unit where the DIE for the variable is
+    /// * `memory` - A reference to a struct that implements the `MemoryAccess`
+    ///   trait.
+    /// * `section_offset` - A offset to the compilation unit where the DIE for
+    ///   the variable is
     /// located.
-    /// * `unit_offset` - A offset into the compilation unit where the DIE representing the
+    /// * `unit_offset` - A offset into the compilation unit where the DIE
+    ///   representing the
     /// variable is located.
-    /// * `frame_base` - The value of the frame base, which is often needed to evaluate the
+    /// * `frame_base` - The value of the frame base, which is often needed to
+    ///   evaluate the
     /// variable.
     /// * `cwd` - The work directory of the program being debugged.
     ///
-    /// This function will go through the DIE in the compilation unit to find the necessary
-    /// debug information.
+    /// This function will go through the DIE in the compilation unit to find
+    /// the necessary debug information.
     /// Then it will use that information to evaluate the value of the variable.
     pub fn get_variable<M: MemoryAccess>(
         dwarf: &Dwarf<R>,
@@ -155,7 +161,8 @@ impl<R: Reader<Offset = usize>> Variable<R> {
     }
 }
 
-/// Will check if the given DIE has one of the DWARF tags that represents a variable.
+/// Will check if the given DIE has one of the DWARF tags that represents a
+/// variable.
 ///
 /// Description:
 ///
@@ -165,7 +172,8 @@ impl<R: Reader<Offset = usize>> Variable<R> {
 /// - DW_TAG_variable
 /// - DW_TAG_formal_parameter
 /// - DW_TAG_constant
-/// If the DIE has one of the tags the function will return `true`, otherwise `false`.
+/// If the DIE has one of the tags the function will return `true`, otherwise
+/// `false`.
 pub fn is_variable_die<R: Reader<Offset = usize>>(die: &DebuggingInformationEntry<R>) -> bool {
     // Check that it is a variable.
     die.tag() == gimli::DW_TAG_variable
@@ -178,15 +186,16 @@ pub fn is_variable_die<R: Reader<Offset = usize>>(die: &DebuggingInformationEntr
 /// Description:
 ///
 /// * `dwarf` - A reference to gimli-rs `Dwarf` struct.
-/// * `unit` - A reference to gimli-rs `Unit` struct, which the given DIE is located in.
+/// * `unit` - A reference to gimli-rs `Unit` struct, which the given DIE is
+///   located in.
 /// * `die` - A reference to DIE.
 ///
-/// Will check if the given DIE represents a variable, if it does not it will return a error.
-/// After that it will try to evaluate the `DW_AT_name` attribute and return the result.
-/// But if it dose not have the name attribute it will try to get the name from the DIE in the
-/// `DW_AT_abstract_origin` attribute.
-/// If that attribute is missing it will return `Ok(None)`, because the variable does not have a
-/// name.
+/// Will check if the given DIE represents a variable, if it does not it will
+/// return a error. After that it will try to evaluate the `DW_AT_name`
+/// attribute and return the result. But if it dose not have the name attribute
+/// it will try to get the name from the DIE in the `DW_AT_abstract_origin`
+/// attribute. If that attribute is missing it will return `Ok(None)`, because
+/// the variable does not have a name.
 pub fn get_var_name<R: Reader<Offset = usize>>(
     dwarf: &Dwarf<R>,
     unit: &Unit<R>,
@@ -234,11 +243,12 @@ pub enum VariableLocation<R: Reader<Offset = usize>> {
     /// The gimli-rs expression that describes the location of the variable.
     Expression(gimli::Expression<R>),
 
-    /// The gimli-rs location list entry that describes the location of the Variable.
+    /// The gimli-rs location list entry that describes the location of the
+    /// Variable.
     LocationListEntry(gimli::LocationListEntry<R>),
 
-    /// The variable has no location currently but had or will have one. Note that the location can
-    /// be a constant stored in the DWARF stack.
+    /// The variable has no location currently but had or will have one. Note
+    /// that the location can be a constant stored in the DWARF stack.
     LocationOutOfRange,
 
     /// The variable has no location.
@@ -250,11 +260,14 @@ pub enum VariableLocation<R: Reader<Offset = usize>> {
 /// Description:
 ///
 /// * `dwarf` - A reference to gimli-rs `Dwarf` struct.
-/// * `unit` - A reference to gimli-rs `Unit` struct which contains the given DIE.
+/// * `unit` - A reference to gimli-rs `Unit` struct which contains the given
+///   DIE.
 /// * `die` - A reference to the variables DIE that contains the location.
-/// * `address` - A address that will be used to find the location, this is most often the current machine code address.
+/// * `address` - A address that will be used to find the location, this is most
+///   often the current machine code address.
 ///
-/// Will get the location for the given address from the attribute `DW_AT_location` in the variable DIE.
+/// Will get the location for the given address from the attribute
+/// `DW_AT_location` in the variable DIE.
 pub fn find_variable_location<R: Reader<Offset = usize>>(
     dwarf: &Dwarf<R>,
     unit: &Unit<R>,
@@ -296,12 +309,14 @@ pub fn find_variable_location<R: Reader<Offset = usize>>(
 /// Description:
 ///
 /// * `dwarf` - A reference to gimli-rs `Dwarf` struct.
-/// * `unit` - A reference to gimli-rs `Unit` struct, which the given DIE is located in.
-/// * `die` - A reference to the DIE representing a variable, which the resulting type DIE will represent the type off..
+/// * `unit` - A reference to gimli-rs `Unit` struct, which the given DIE is
+///   located in.
+/// * `die` - A reference to the DIE representing a variable, which the
+///   resulting type DIE will represent the type off..
 ///
-/// Will find the DIE representing the type of the variable that the given DIE represents.
-/// The type DIE is found using the attribute `DW_AT_type` in the given DIE or in the DIE from the
-/// attribute `DW_AT_abstract_origin`.
+/// Will find the DIE representing the type of the variable that the given DIE
+/// represents. The type DIE is found using the attribute `DW_AT_type` in the
+/// given DIE or in the DIE from the attribute `DW_AT_abstract_origin`.
 pub fn find_variable_type_die<R: Reader<Offset = usize>>(
     dwarf: &Dwarf<R>,
     unit: &Unit<R>,
@@ -351,13 +366,15 @@ pub fn find_variable_type_die<R: Reader<Offset = usize>>(
 /// Description:
 ///
 /// * `dwarf` - A reference to gimli-rs `Dwarf` struct.
-/// * `unit` - A reference to gimli-rs `Unit` struct, which the given DIE is located in.
+/// * `unit` - A reference to gimli-rs `Unit` struct, which the given DIE is
+///   located in.
 /// * `die` - A reference to DIE.
 /// * `cwd` - The work directory of the debugged program.
 ///
-/// This function will retrieve the source code location where the variable was declared.
-/// The information is retrieved from the  attributes starting with `DW_AT_decl_` in the given DIE,
-/// or in the DIE found in the attribute `DW_AT_abstract_origin`.
+/// This function will retrieve the source code location where the variable was
+/// declared. The information is retrieved from the  attributes starting with
+/// `DW_AT_decl_` in the given DIE, or in the DIE found in the attribute
+/// `DW_AT_abstract_origin`.
 pub fn find_variable_source_information<R: Reader<Offset = usize>>(
     dwarf: &Dwarf<R>,
     unit: &Unit<R>,


### PR DESCRIPTION
Hi Niklas, hope all is well!

I needed to bump the version of the gimli crate in rust debug to be able to use it in Symex for symbolic execution, so I figured that I might aswell upstream it here. I applied cargo fmt while I was at it, if you do not want this fmt change then I can simply re-do the same changes but without formatting.

## Key changes

1. Updates gimli and modifies code to match
2. Applies cargo fmt
3. Bump version as we change the gimli version